### PR TITLE
NULL terminate array as test_minmea_check expects

### DIFF
--- a/tests.c
+++ b/tests.c
@@ -18,6 +18,7 @@
 
 static const char *valid_sentences_nochecksum[] = {
     "$GPTXT,xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    NULL,
 };
 
 static const char *valid_sentences_checksum[] = {


### PR DESCRIPTION
Just a bug where `test_minmea_check` expects this array to be null terminated like the other two.
