### PR TITLE
use explicit 32bit integer for fractional time calculation

### DIFF
--- a/minmea.c
+++ b/minmea.c
@@ -300,8 +300,8 @@ bool minmea_scan(const char *sentence, const char *format, ...)
 
                     // Extra: fractional time. Saved as microseconds.
                     if (*field++ == '.') {
-                        int value = 0;
-                        int scale = 1000000;
+                        uint32_t value = 0;
+                        uint32_t scale = 1000000LU;
                         while (isdigit((unsigned char) *field) && scale > 1) {
                             value = (value * 10) + (*field++ - '0');
                             scale /= 10;


### PR DESCRIPTION
Otherwise, the build fails on non-32bit platforms:

```
minmea.c: In function 'minmea_scan':
minmea.c:304:37: error: overflow in implicit constant conversion [-Werror=overflow]
                         int scale = 1000000;
```

The tests still pass after this change on 64bit Linux.