### PR TITLE
Change dgps_age type from int to minmea_float

### DIFF
--- a/minmea.c
+++ b/minmea.c
@@ -415,7 +415,7 @@ bool minmea_parse_gga(struct minmea_sentence_gga *frame, const char *sentence)
     int latitude_direction;
     int longitude_direction;
 
-    if (!minmea_scan(sentence, "tTfdfdiiffcfci_",
+    if (!minmea_scan(sentence, "tTfdfdiiffcfcf_",
             type,
             &frame->time,
             &frame->latitude, &latitude_direction,

--- a/minmea.h
+++ b/minmea.h
@@ -76,7 +76,7 @@ struct minmea_sentence_gga {
     struct minmea_float hdop;
     struct minmea_float altitude; char altitude_units;
     struct minmea_float height; char height_units;
-    int dgps_age;
+    struct minmea_float dgps_age;
 };
 
 enum minmea_gll_status {

--- a/tests.c
+++ b/tests.c
@@ -525,7 +525,7 @@ START_TEST(test_minmea_parse_gga1)
     ck_assert(minmea_check(sentence, true) == true);
     ck_assert(minmea_parse_gga(&frame, sentence) == true);
     memset(&expected.altitude_units + 1, 0, 3);
-	memset(&expected.height_units + 1, 0, 3);
+    memset(&expected.height_units + 1, 0, 3);
     ck_assert(!memcmp(&frame, &expected, sizeof(frame)));
 }
 END_TEST

--- a/tests.c
+++ b/tests.c
@@ -507,8 +507,8 @@ END_TEST
 START_TEST(test_minmea_parse_gga1)
 {
     const char *sentence = "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47";
-    struct minmea_sentence_gga frame = { 0 };
-    struct minmea_sentence_gga expected = { 0 };
+    struct minmea_sentence_gga frame = {};
+    struct minmea_sentence_gga expected = {};
     expected.time = (struct minmea_time) { 12, 35, 19, 0 };
     expected.latitude = (struct minmea_float) { 4807038, 1000 };
     expected.longitude = (struct minmea_float) { 1131000, 1000 };

--- a/tests.c
+++ b/tests.c
@@ -519,7 +519,7 @@ START_TEST(test_minmea_parse_gga1)
         .altitude_units = 'M',
         .height = { 469, 10 },
         .height_units = 'M',
-        .dgps_age = 0,
+        .dgps_age = { 0, 10 },
     };
     ck_assert(minmea_check(sentence, false) == true);
     ck_assert(minmea_check(sentence, true) == true);

--- a/tests.c
+++ b/tests.c
@@ -508,7 +508,8 @@ START_TEST(test_minmea_parse_gga1)
 {
     const char *sentence = "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47";
     struct minmea_sentence_gga frame = {};
-    struct minmea_sentence_gga expected = {
+    struct minmea_sentence_gga expected = {};
+    expected = (struct minmea_sentence_gga) {
         .time = { 12, 35, 19, 0 },
         .latitude = { 4807038, 1000 },
         .longitude = { 1131000, 1000 },
@@ -524,8 +525,6 @@ START_TEST(test_minmea_parse_gga1)
     ck_assert(minmea_check(sentence, false) == true);
     ck_assert(minmea_check(sentence, true) == true);
     ck_assert(minmea_parse_gga(&frame, sentence) == true);
-    memset(&expected.altitude_units + 1, 0, 3);
-    memset(&expected.height_units + 1, 0, 3);
     ck_assert(!memcmp(&frame, &expected, sizeof(frame)));
 }
 END_TEST

--- a/tests.c
+++ b/tests.c
@@ -509,19 +509,17 @@ START_TEST(test_minmea_parse_gga1)
     const char *sentence = "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47";
     struct minmea_sentence_gga frame = {};
     struct minmea_sentence_gga expected = {};
-    expected = (struct minmea_sentence_gga) {
-        .time = { 12, 35, 19, 0 },
-        .latitude = { 4807038, 1000 },
-        .longitude = { 1131000, 1000 },
-        .fix_quality = 1,
-        .satellites_tracked = 8,
-        .hdop = { 9, 10 },
-        .altitude = { 5454, 10 },
-        .altitude_units = 'M',
-        .height = { 469, 10 },
-        .height_units = 'M',
-        .dgps_age = { 0, 0 },
-    };
+    expected.time = { 12, 35, 19, 0 };
+	expected.latitude = { 4807038, 1000 };
+	expected.longitude = { 1131000, 1000 };
+	expected.fix_quality = 1;
+	expected.satellites_tracked = 8;
+	expected.hdop = { 9, 10 };
+	expected.altitude = { 5454, 10 };
+	expected.altitude_units = 'M';
+	expected.height = { 469, 10 };
+	expected.height_units = 'M';
+	expected.dgps_age = { 0, 0 };
     ck_assert(minmea_check(sentence, false) == true);
     ck_assert(minmea_check(sentence, true) == true);
     ck_assert(minmea_parse_gga(&frame, sentence) == true);

--- a/tests.c
+++ b/tests.c
@@ -507,19 +507,19 @@ END_TEST
 START_TEST(test_minmea_parse_gga1)
 {
     const char *sentence = "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47";
-    struct minmea_sentence_gga frame = {};
-    struct minmea_sentence_gga expected = {};
-    expected.time = { 12, 35, 19, 0 };
-	expected.latitude = { 4807038, 1000 };
-	expected.longitude = { 1131000, 1000 };
-	expected.fix_quality = 1;
-	expected.satellites_tracked = 8;
-	expected.hdop = { 9, 10 };
-	expected.altitude = { 5454, 10 };
-	expected.altitude_units = 'M';
-	expected.height = { 469, 10 };
-	expected.height_units = 'M';
-	expected.dgps_age = { 0, 0 };
+    struct minmea_sentence_gga frame = { 0 };
+    struct minmea_sentence_gga expected = { 0 };
+    expected.time = (struct minmea_time) { 12, 35, 19, 0 };
+    expected.latitude = (struct minmea_float) { 4807038, 1000 };
+    expected.longitude = (struct minmea_float) { 1131000, 1000 };
+    expected.fix_quality = 1;
+    expected.satellites_tracked = 8;
+    expected.hdop = (struct minmea_float) { 9, 10 };
+    expected.altitude = (struct minmea_float) { 5454, 10 };
+    expected.altitude_units = 'M';
+    expected.height = (struct minmea_float) { 469, 10 };
+    expected.height_units = 'M';
+    expected.dgps_age = (struct minmea_float) { 0, 0 };
     ck_assert(minmea_check(sentence, false) == true);
     ck_assert(minmea_check(sentence, true) == true);
     ck_assert(minmea_parse_gga(&frame, sentence) == true);

--- a/tests.c
+++ b/tests.c
@@ -508,7 +508,7 @@ START_TEST(test_minmea_parse_gga1)
 {
     const char *sentence = "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47";
     struct minmea_sentence_gga frame = {};
-    static const struct minmea_sentence_gga expected = {
+    struct minmea_sentence_gga expected = {
         .time = { 12, 35, 19, 0 },
         .latitude = { 4807038, 1000 },
         .longitude = { 1131000, 1000 },
@@ -519,11 +519,13 @@ START_TEST(test_minmea_parse_gga1)
         .altitude_units = 'M',
         .height = { 469, 10 },
         .height_units = 'M',
-        .dgps_age = { 0, 10 },
+        .dgps_age = { 0, 0 },
     };
     ck_assert(minmea_check(sentence, false) == true);
     ck_assert(minmea_check(sentence, true) == true);
     ck_assert(minmea_parse_gga(&frame, sentence) == true);
+    memset(&expected.altitude_units + 1, 0, 3);
+	memset(&expected.height_units + 1, 0, 3);
     ck_assert(!memcmp(&frame, &expected, sizeof(frame)));
 }
 END_TEST


### PR DESCRIPTION
As shown in `http://www.catb.org/gpsd/NMEA.html#_gga_global_positioning_system_fix_data`:
```
$--GGA,hhmmss.ss,llll.ll,a,yyyyy.yy,a,x,xx,x.x,x.x,M,x.x,M,x.x,xxxx*hh<CR><LF>
                                                            ↑
                                                         dgps_age
```
dgps_age is a float type instead of int.