### PR TITLE
🔗 update Check link

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ good to go.
 
 Building and running the tests requires the following:
 
-* Check Framework (http://check.sourceforge.net/).
-* Clang Static Analyzer (http://clang-analyzer.llvm.org/).
+* Check Framework (https://libcheck.github.io/check/).
+* Clang Static Analyzer (https://clang-analyzer.llvm.org/).
 
 If you have both in your ``$PATH``, running the tests should be as simple as
 typing ``make``.


### PR DESCRIPTION
Check has moved to github from sourceforge, update the link.

Also switch clang static analyzer link to https from http.

BTW, great library, thanks for sharing it :grinning:  !