### PR TITLE
👨‍🏭 enable test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ minmea
 tests
 example
 *.exe
+*.gcno
+*.gcda
+*.info
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,20 @@
-language: c
-compiler:
-  - gcc
-  - clang
-install: sudo apt-get install check
-script: make test
+sudo: required
+
+language: generic
+
+services:
+  - docker
+
+# defer this build to a docker container to work around travis limitations on
+# linux distro version, and more explicitly control compiler tools versions.
+script:
+  - docker build -t minmea-test .
+  - docker run --cap-add SYS_PTRACE -e "TRAVIS_JOB_ID=$TRAVIS_JOB_ID"
+    -e "CC=gcc-7" -e "LCOV=lcov" -e "MINMEA_COVERAGE=1" -e "MINMEA_ASAN=1"
+    minmea-test
+  - docker run --cap-add SYS_PTRACE -e "TRAVIS_JOB_ID=$TRAVIS_JOB_ID"
+    -e "CC=clang-6.0" -e "MINMEA_COVERAGE=1" -e "MINMEA_ASAN=1" minmea-test
+
 notifications:
   email:
     on_success: change

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:bionic
+
+RUN apt-get update
+RUN apt-get install -y \
+  build-essential \
+  check \
+  clang-6.0 \
+  gcc \
+  git \
+  lcov \
+  pkg-config \
+  python \
+  python-pip
+
+RUN pip install cpp-coveralls
+
+COPY . /tmp/minmea
+
+CMD bash -c \
+  "cd /tmp/minmea && \
+  make test -j6 && \
+  if [ -f coverage_filtered.info ]; \
+  then coveralls -n -i ./ -e example.c -l coverage_filtered.info; \
+  fi"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,19 @@
 
 CFLAGS = -g -Wall -Wextra -Werror -std=c99
 CFLAGS += -D_POSIX_C_SOURCE=199309L -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_DARWIN_C_SOURCE
+
+ifeq ($(MINMEA_COVERAGE),1)
+CFLAGS += -fprofile-arcs -ftest-coverage --coverage
+
+# Set LCOV if available
+LCOV := $(shell command -v lcov 2> /dev/null)
+endif
+
+# Optionally use AddressSanitizer and UndefinedBehaviorSanitizer
+ifeq ($(MINMEA_ASAN),1)
+CFLAGS += -fsanitize=address -fsanitize=undefined
+endif
+
 CFLAGS += $(shell pkg-config --cflags check)
 LDLIBS += $(shell pkg-config --libs check)
 
@@ -15,6 +28,16 @@ all: scan-build test example
 test: tests
 	@echo "+++ Running Check test suite..."
 	./tests
+	@# Run coverage if enabled
+ifeq ($(MINMEA_COVERAGE),1)
+ifdef LCOV
+	@echo "+++ Running lcov..."
+	lcov --quiet --rc lcov_branch_coverage=1 --capture --directory ./ --output-file coverage.info
+	lcov --quiet --rc lcov_branch_coverage=1 --remove coverage.info "*test*" -o coverage_filtered.info
+	genhtml --branch-coverage coverage_filtered.info --output-directory coverage
+	@echo "See file://$(abspath coverage)/index.html for lcov results"
+endif
+endif
 
 scan-build: clean
 	@echo "+++ Running Clang Static Analyzer..."
@@ -24,7 +47,11 @@ clean:
 	$(RM) tests example *.o
 
 tests: tests.o minmea.o
+	$(CC) $(CFLAGS) $^ $(LDLIBS) -o $@
+
 example: example.o minmea.o
+	$(CC) $(CFLAGS) $^ $(LDLIBS) -o $@
+
 tests.o: tests.c minmea.h
 minmea.o: minmea.c minmea.h
 

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ CFLAGS = -g -Wall -Wextra -Werror -std=c99
 CFLAGS += -D_POSIX_C_SOURCE=199309L -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_DARWIN_C_SOURCE
 
 ifeq ($(MINMEA_COVERAGE),1)
-CFLAGS += -fprofile-arcs -ftest-coverage --coverage
+CFLAGS += --coverage
 
 # Set LCOV if available
-LCOV := $(shell command -v lcov 2> /dev/null)
+LCOV ?=
 endif
 
 # Optionally use AddressSanitizer and UndefinedBehaviorSanitizer
@@ -32,8 +32,8 @@ test: tests
 ifeq ($(MINMEA_COVERAGE),1)
 ifdef LCOV
 	@echo "+++ Running lcov..."
-	lcov --quiet --rc lcov_branch_coverage=1 --capture --directory ./ --output-file coverage.info
-	lcov --quiet --rc lcov_branch_coverage=1 --remove coverage.info "*test*" -o coverage_filtered.info
+	$(LCOV) --quiet --rc lcov_branch_coverage=1 --capture --directory ./ --output-file coverage.info
+	$(LCOV) --quiet --rc lcov_branch_coverage=1 --remove coverage.info "*test*" -o coverage_filtered.info
 	genhtml --branch-coverage coverage_filtered.info --output-directory coverage
 	@echo "See file://$(abspath coverage)/index.html for lcov results"
 endif

--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ Building and running the tests requires the following:
 If you have both in your ``$PATH``, running the tests should be as simple as
 typing ``make``.
 
+You can optionally also enable coverage information and/or enable address and
+undefined behavior sanitizers when building and running the unit tests.
+Note that these features may require modern versions of gcc or clang (tested on
+gcc-8 and clang-7).
+This example enables both sanitizers and coverage:
+```bash
+MINMEA_COVERAGE=1 LCOV=lcov MINMEA_ASAN=1 CC=gcc-8 make
+...
+# if $LCOV is set to an appropriate coverage analysis tool (as above), html
+# output is generated at the end of the run and you'll see this print:
+See file://path-to-minmea-repo/coverage/index.html for lcov results
+```
+
 ## Limitations
 
 * Only a handful of frames is supported right now.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ typing ``make``.
 You can optionally also enable coverage information and/or enable address and
 undefined behavior sanitizers when building and running the unit tests.
 Note that these features may require modern versions of gcc or clang (tested on
-gcc-8 and clang-7).
+gcc-8 and clang-7), and coverage is only supported with gcc.
 This example enables both sanitizers and coverage:
 ```bash
 MINMEA_COVERAGE=1 LCOV=lcov MINMEA_ASAN=1 CC=gcc-8 make


### PR DESCRIPTION
Add optional coverage output and if `lcov` is available, html report
output.

Coverage is enabled if the env variable `MINMEA_COVERAGE` is set to 1.

Also add optional AddressSanitizer and UndefinedBehaviorSanitizer, only
enabled if the env variable `MINMEA_ASAN` is set to 1.

Example:
```bash
MINMEA_COVERAGE=1 MINMEA_ASAN=1 make -j6
...
+++ Running lcov...
lcov --quiet --rc lcov_branch_coverage=1 --capture --directory ./ --output-file coverage.info
lcov --quiet --rc lcov_branch_coverage=1 --remove coverage.info "*test*" -o coverage_filtered.info
genhtml --branch-coverage coverage_filtered.info --output-directory coverage
Reading data file coverage_filtered.info
Found 2 entries.
Found common filename prefix "/home/noah/dev/github"
Writing .css and .png files.
Generating output.
Processing file minmea/minmea.h
Processing file minmea/minmea.c
Writing directory view page.
Overall coverage rate:
  lines......: 91.1% (318 of 349 lines)
  functions..: 100.0% (19 of 19 functions)
  branches...: 75.5% (241 of 319 branches)
See file://minmea/coverage/index.html for lcov results
+++ All good.
```