### PR TITLE
minmea: Allow lines with only CR ending

### DIFF
--- a/minmea.c
+++ b/minmea.c
@@ -79,7 +79,7 @@ bool minmea_check(const char *sentence, bool strict)
     }
 
     // The only stuff allowed at this point is a newline.
-    if (*sentence && strcmp(sentence, "\n") && strcmp(sentence, "\r\n"))
+    if (*sentence && strcmp(sentence, "\n") != 0 && strcmp(sentence, "\r") != 0 && strcmp(sentence, "\r\n") != 0)
         return false;
 
     return true;

--- a/minmea.c
+++ b/minmea.c
@@ -79,8 +79,13 @@ bool minmea_check(const char *sentence, bool strict)
     }
 
     // The only stuff allowed at this point is a newline.
-    if (*sentence && strcmp(sentence, "\n") != 0 && strcmp(sentence, "\r") != 0 && strcmp(sentence, "\r\n") != 0)
+    while (*sentence == '\r' || *sentence == '\n') {
+        sentence++;
+    }
+    
+    if (*sentence) {
         return false;
+    }
 
     return true;
 }

--- a/tests.c
+++ b/tests.c
@@ -18,6 +18,11 @@
 
 static const char *valid_sentences_nochecksum[] = {
     "$GPTXT,xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "$GPTXT,hello\n",
+    "$GPTXT,hello\r",
+    "$GPTXT,hello\r\n",
+    "$GPTXT,hello\r\n\r\n",
+    "$GPTXT,hello\n\r\r\n",
     NULL,
 };
 
@@ -55,6 +60,9 @@ static const char *invalid_sentences[] = {
     "gps: $GPGLL,,,,,,V,N",
     "$GPXTE,A,A,0.67,L,N*6e",
     "$GPXTE,A,A,0.67,L,N*6g",
+    "$GPTXT,hello\n ",
+    "$GPTXT,hello\r*24",
+    "$GPTXT,hello\r\n$",
     NULL,
 };
 


### PR DESCRIPTION
Hello,

I would like to propose a small change that allows processing of lines that end with CR only. I use tokenization of lines which are read from a GPS module with `strtok()` call with `'\n` as delimiter.

So that `minmea_check()` in the current implementation returns false as all lines do not end with either `"\n"` or `"\r\n"`.

Let me know if it is applicable change.