### PR TITLE
add minmea_getdate()

### DIFF
--- a/minmea.c
+++ b/minmea.c
@@ -612,7 +612,7 @@ bool minmea_parse_zda(struct minmea_sentence_zda *frame, const char *sentence)
   return true;
 }
 
-int minmea_getdate(struct tm *tm, const struct minmea_date *date, const struct minmea_time *time_)
+int minmea_getdatetime(struct tm *tm, const struct minmea_date *date, const struct minmea_time *time_)
 {
     if (date->year == -1 || time_->hours == -1)
         return -1;
@@ -637,7 +637,7 @@ int minmea_getdate(struct tm *tm, const struct minmea_date *date, const struct m
 int minmea_gettime(struct timespec *ts, const struct minmea_date *date, const struct minmea_time *time_)
 {
     struct tm tm;
-    if (minmea_getdate(&tm, date, time_))
+    if (minmea_getdatetime(&tm, date, time_))
         return -1;
 
     time_t timestamp = timegm(&tm); /* See README.md if your system lacks timegm(). */

--- a/minmea.c
+++ b/minmea.c
@@ -612,24 +612,24 @@ bool minmea_parse_zda(struct minmea_sentence_zda *frame, const char *sentence)
   return true;
 }
 
-int minmea_getdate(struct tm *out, const struct minmea_date *date, const struct minmea_time *time_)
+int minmea_getdate(struct tm *tm, const struct minmea_date *date, const struct minmea_time *time_)
 {
     if (date->year == -1 || time_->hours == -1)
         return -1;
 
-    memset(out, 0, sizeof(*out));
+    memset(tm, 0, sizeof(*tm));
     if (date->year < 80) {
-        out->tm_year = 2000 + date->year - 1900; // 2000-2079
+        tm->tm_year = 2000 + date->year - 1900; // 2000-2079
     } else if (date->year >= 1900) {
-        out->tm_year = date->year - 1900;        // 4 digit year, use directly
+        tm->tm_year = date->year - 1900;        // 4 digit year, use directly
     } else {
-        out->tm_year = date->year;               // 1980-1999
+        tm->tm_year = date->year;               // 1980-1999
     }
-    out->tm_mon = date->month - 1;
-    out->tm_mday = date->day;
-    out->tm_hour = time_->hours;
-    out->tm_min = time_->minutes;
-    out->tm_sec = time_->seconds;
+    tm->tm_mon = date->month - 1;
+    tm->tm_mday = date->day;
+    tm->tm_hour = time_->hours;
+    tm->tm_min = time_->minutes;
+    tm->tm_sec = time_->seconds;
 
     return 0;
 }

--- a/minmea.c
+++ b/minmea.c
@@ -617,7 +617,7 @@ int minmea_getdate(struct tm *out, const struct minmea_date *date, const struct 
     if (date->year == -1 || time_->hours == -1)
         return -1;
 
-    memset(out, 0, sizeof(struct tm));
+    memset(out, 0, sizeof(*out));
     if (date->year < 80) {
         out->tm_year = 2000 + date->year - 1900; // 2000-2079
     } else if (date->year >= 1900) {

--- a/minmea.h
+++ b/minmea.h
@@ -209,6 +209,11 @@ bool minmea_parse_vtg(struct minmea_sentence_vtg *frame, const char *sentence);
 bool minmea_parse_zda(struct minmea_sentence_zda *frame, const char *sentence);
 
 /**
+ * Convert GPS UTC date/time representation to a UNIX calendar time.
+ */
+int minmea_getdate(struct tm *out, const struct minmea_date *date, const struct minmea_time *time_);
+
+/**
  * Convert GPS UTC date/time representation to a UNIX timestamp.
  */
 int minmea_gettime(struct timespec *ts, const struct minmea_date *date, const struct minmea_time *time_);

--- a/minmea.h
+++ b/minmea.h
@@ -211,7 +211,7 @@ bool minmea_parse_zda(struct minmea_sentence_zda *frame, const char *sentence);
 /**
  * Convert GPS UTC date/time representation to a UNIX calendar time.
  */
-int minmea_getdate(struct tm *tm, const struct minmea_date *date, const struct minmea_time *time_);
+int minmea_getdatetime(struct tm *tm, const struct minmea_date *date, const struct minmea_time *time_);
 
 /**
  * Convert GPS UTC date/time representation to a UNIX timestamp.

--- a/minmea.h
+++ b/minmea.h
@@ -211,7 +211,7 @@ bool minmea_parse_zda(struct minmea_sentence_zda *frame, const char *sentence);
 /**
  * Convert GPS UTC date/time representation to a UNIX calendar time.
  */
-int minmea_getdate(struct tm *out, const struct minmea_date *date, const struct minmea_time *time_);
+int minmea_getdate(struct tm *tm, const struct minmea_date *date, const struct minmea_time *time_);
 
 /**
  * Convert GPS UTC date/time representation to a UNIX timestamp.

--- a/tests.c
+++ b/tests.c
@@ -945,50 +945,76 @@ START_TEST(test_minmea_gettime)
 {
     struct minmea_date d = { 14, 2, 14 };
     struct minmea_time t = { 13, 0, 9, 123456 };
+    struct tm tm;
     struct timespec ts;
+    ck_assert(minmea_getdatetime(&tm, &d, &t) == 0);
     ck_assert(minmea_gettime(&ts, &d, &t) == 0);
+    ck_assert_int_eq(tm.tm_year, 2014-1900);
+    ck_assert_int_eq(tm.tm_mon, 1);
+    ck_assert_int_eq(tm.tm_mday, 14);
+    ck_assert_int_eq(tm.tm_hour, 13);
+    ck_assert_int_eq(tm.tm_min, 0);
+    ck_assert_int_eq(tm.tm_sec, 9);
     ck_assert_int_eq(ts.tv_sec, 1392382809);
     ck_assert_int_eq(ts.tv_nsec, 123456000);
 
     d.year = -1;
+    ck_assert(minmea_getdatetime(&tm, &d, &t) != 0);
     ck_assert(minmea_gettime(&ts, &d, &t) != 0);
     d.year = 14;
 
     t.hours = -1;
+    ck_assert(minmea_getdatetime(&tm, &d, &t) != 0);
     ck_assert(minmea_gettime(&ts, &d, &t) != 0);
     t.hours = 13;
 
     /* two digit year conversions */
     d.year = 80;
+    ck_assert(minmea_getdatetime(&tm, &d, &t) == 0);
     ck_assert(minmea_gettime(&ts, &d, &t) == 0);
+    ck_assert_int_eq(tm.tm_year, 1980-1900);
     ck_assert_int_eq(ts.tv_sec, 319381209);      /* 1980 */
     d.year = 37;
+    ck_assert(minmea_getdatetime(&tm, &d, &t) == 0);
     ck_assert(minmea_gettime(&ts, &d, &t) == 0);
+    ck_assert_int_eq(tm.tm_year, 2037-1900);
     ck_assert_int_eq(ts.tv_sec, 2118229209);     /* 2037 */
     /* skip >= 2038 tests on 32-bit time_t platforms */
     if (sizeof(time_t) == sizeof(int64_t)) {
         d.year = 79;
+        ck_assert(minmea_getdatetime(&tm, &d, &t) == 0);
         ck_assert(minmea_gettime(&ts, &d, &t) == 0);
+        ck_assert_int_eq(tm.tm_year, 2079-1900);
         ck_assert_int_eq(ts.tv_sec, 3443605209); /* 2079 */
     }
 
     /* four digit year conversions */
     d.year = 1979;
+    ck_assert(minmea_getdatetime(&tm, &d, &t) == 0);
     ck_assert(minmea_gettime(&ts, &d, &t) == 0);
+    ck_assert_int_eq(tm.tm_year, 1979-1900);
     ck_assert_int_eq(ts.tv_sec, 287845209);
     d.year = 1980;
+    ck_assert(minmea_getdatetime(&tm, &d, &t) == 0);
     ck_assert(minmea_gettime(&ts, &d, &t) == 0);
+    ck_assert_int_eq(tm.tm_year, 1980-1900);
     ck_assert_int_eq(ts.tv_sec, 319381209);
     d.year = 2037;
+    ck_assert(minmea_getdatetime(&tm, &d, &t) == 0);
     ck_assert(minmea_gettime(&ts, &d, &t) == 0);
+    ck_assert_int_eq(tm.tm_year, 2037-1900);
     ck_assert_int_eq(ts.tv_sec, 2118229209);
     /* skip >= 2038 tests on 32-bit time_t platforms */
     if (sizeof(time_t) == sizeof(int64_t)) {
         d.year = 2079;
+        ck_assert(minmea_getdatetime(&tm, &d, &t) == 0);
         ck_assert(minmea_gettime(&ts, &d, &t) == 0);
+        ck_assert_int_eq(tm.tm_year, 2079-1900);
         ck_assert_int_eq(ts.tv_sec, 3443605209);
         d.year = 2080;
+        ck_assert(minmea_getdatetime(&tm, &d, &t) == 0);
         ck_assert(minmea_gettime(&ts, &d, &t) == 0);
+        ck_assert_int_eq(tm.tm_year, 2080-1900);
         ck_assert_int_eq(ts.tv_sec, 3475141209);
     }
 }


### PR DESCRIPTION
I needed a `struct tm` instead of a Unix timestamp.
The struct is already being assembled in `minmea_gettime()` and converting `struct tm`  -> `time_t` -> `struct tm` is silly, so I added a function to make that functionality available for external users. 