### PR TITLE
set "\r" "\r\n" "\n" is allowed at the end of this sentence.

### DIFF
--- a/minmea.c
+++ b/minmea.c
@@ -79,10 +79,19 @@ bool minmea_check(const char *sentence, bool strict)
     }
 
     // The only stuff allowed at this point is a newline.
-    if (*sentence && strcmp(sentence, "\n") && strcmp(sentence, "\r\n"))
+    // "\r" "\r\n" "\n" is allowed at this point
+    if (*sentence && 
+        ((strlen(sentence)==1 && strcmp(sentence, "\n")) || 
+        (strlen(sentence)==1 && strcmp(sentence, "\r")) || 
+        (strlen(sentence)==2 && strcmp(sentence, "\r\n")))){
+        return true;
+    }
+    else if(sentence == NULL){
+        return true;
+    }
+    else{
         return false;
-
-    return true;
+    }
 }
 
 static inline bool minmea_isfield(char c) {


### PR DESCRIPTION
when sentence end is "\r" "\n" "\r\n",minmea_check will return falase.This is not the expected result.We should let minmea_check return true when “\r” "\n" "\r\n" at end of sentence