### PR TITLE
tests.c - Fix 'format-security' warnings due to use of ck_assert_msg(…

### DIFF
--- a/tests.c
+++ b/tests.c
@@ -76,18 +76,18 @@ END_TEST
 START_TEST(test_minmea_check)
 {
     for (const char **sentence=valid_sentences_nochecksum; *sentence; sentence++) {
-        ck_assert_msg(minmea_check(*sentence, false) == true, *sentence);
-        ck_assert_msg(minmea_check(*sentence, true) == false, *sentence);
+        ck_assert_msg(minmea_check(*sentence, false) == true, "%s", *sentence);
+        ck_assert_msg(minmea_check(*sentence, true) == false, "%s", *sentence);
     }
 
     for (const char **sentence=valid_sentences_checksum; *sentence; sentence++) {
-        ck_assert_msg(minmea_check(*sentence, false) == true, *sentence);
-        ck_assert_msg(minmea_check(*sentence, true) == true, *sentence);
+        ck_assert_msg(minmea_check(*sentence, false) == true, "%s", *sentence);
+        ck_assert_msg(minmea_check(*sentence, true) == true, "%s", *sentence);
     }
 
     for (const char **sentence=invalid_sentences; *sentence; sentence++) {
-        ck_assert_msg(minmea_check(*sentence, false) == false, *sentence);
-        ck_assert_msg(minmea_check(*sentence, true) == false, *sentence);
+        ck_assert_msg(minmea_check(*sentence, false) == false, "%s", *sentence);
+        ck_assert_msg(minmea_check(*sentence, true) == false, "%s", *sentence);
     }
 }
 END_TEST


### PR DESCRIPTION
…) without a formatting string

https://fedoraproject.org/wiki/Format-Security-FAQ#What_is_-Wformat-security

tests.c: In function ‘test_minmea_check_fn’:
tests.c:79:9: error: format not a string literal and no format arguments [-Werror=format-security]
   79 |         ck_assert_msg(minmea_check(*sentence, false) == true, *sentence);
      |         ^~~~~~~~~~~~~
tests.c:80:9: error: format not a string literal and no format arguments [-Werror=format-security]
   80 |         ck_assert_msg(minmea_check(*sentence, true) == false, *sentence);
      |         ^~~~~~~~~~~~~
tests.c:84:9: error: format not a string literal and no format arguments [-Werror=format-security]
   84 |         ck_assert_msg(minmea_check(*sentence, false) == true, *sentence);
      |         ^~~~~~~~~~~~~
tests.c:85:9: error: format not a string literal and no format arguments [-Werror=format-security]
   85 |         ck_assert_msg(minmea_check(*sentence, true) == true, *sentence);
      |         ^~~~~~~~~~~~~
tests.c:89:9: error: format not a string literal and no format arguments [-Werror=format-security]
   89 |         ck_assert_msg(minmea_check(*sentence, false) == false, *sentence);
      |         ^~~~~~~~~~~~~
tests.c:90:9: error: format not a string literal and no format arguments [-Werror=format-security]
   90 |         ck_assert_msg(minmea_check(*sentence, true) == false, *sentence);
      |         ^~~~~~~~~~~~~