### PR TITLE
should use 'i' instead of 'd' in minmea_parse_gbs

### DIFF
--- a/minmea.c
+++ b/minmea.c
@@ -393,7 +393,7 @@ bool minmea_parse_gbs(struct minmea_sentence_gbs *frame, const char *sentence)
 {
     // $GNGBS,170556.00,3.0,2.9,8.3,,,,*5C
     char type[6];
-    if (!minmea_scan(sentence, "tTfffdfff",
+    if (!minmea_scan(sentence, "tTfffifff",
             type,
             &frame->time,
             &frame->err_latitude,


### PR DESCRIPTION
please reference the definition here:
https://gpsd.gitlab.io/gpsd/NMEA.html#_gbs_gps_satellite_fault_detection