### PR TITLE
Add support for GNS parsing

### DIFF
--- a/minmea.c
+++ b/minmea.c
@@ -405,12 +405,9 @@ bool minmea_parse_gns(struct minmea_sentence_gns *frame, const char *sentence)
 {
     // $GNGNS,103600.01,5114.51176,N,00012.29380,W,ANNN,07,1.18,111.5,45.6,,,V*00
     char type[6];
-    char validity;
     int latitude_direction;
     int longitude_direction;
-    int diffAge;
-    int diffStation;
-    if (!minmea_scan(sentence, "tTfdfdcdfffddc",
+    if (!minmea_scan(sentence, "tTfdfdsifffiic",
             type,
             &frame->time,
             &frame->latitude, &latitude_direction,
@@ -420,16 +417,17 @@ bool minmea_parse_gns(struct minmea_sentence_gns *frame, const char *sentence)
             &frame->hdop,
             &frame->altitude,
             &frame->separation,
-            &diffAge, &diffStation,
-            &validity))
+            &frame->diffAge,
+            &frame->diffStation,
+            &frame->navStatus))
         return false;
     if (strcmp(type+2, "GNS"))
         return false;
 
-    // TODO: figure out if these are the modifications we want
     frame->latitude.value *= latitude_direction;
     frame->longitude.value *= longitude_direction;
-    frame->valid = (validity == 'A');
+
+    return true;
 }
 
 bool minmea_parse_rmc(struct minmea_sentence_rmc *frame, const char *sentence)

--- a/minmea.c
+++ b/minmea.c
@@ -405,6 +405,7 @@ bool minmea_parse_gns(struct minmea_sentence_gns *frame, const char *sentence)
 {
     // $GNGNS,103600.01,5114.51176,N,00012.29380,W,ANNN,07,1.18,111.5,45.6,,,V*00
     char type[6];
+    static char value[7]; // TODO: 7 may be a limit...increase? Also, altenative is pass a buffer to hold this, instead of declaring as static
     int latitude_direction;
     int longitude_direction;
     if (!minmea_scan(sentence, "tTfdfdsifffiic",
@@ -412,7 +413,7 @@ bool minmea_parse_gns(struct minmea_sentence_gns *frame, const char *sentence)
             &frame->time,
             &frame->latitude, &latitude_direction,
             &frame->longitude, &longitude_direction,
-            &frame->posMode,
+            value,
             &frame->numSV,
             &frame->hdop,
             &frame->altitude,
@@ -426,6 +427,7 @@ bool minmea_parse_gns(struct minmea_sentence_gns *frame, const char *sentence)
 
     frame->latitude.value *= latitude_direction;
     frame->longitude.value *= longitude_direction;
+    frame->posMode = value;
 
     return true;
 }

--- a/minmea.c
+++ b/minmea.c
@@ -405,7 +405,8 @@ bool minmea_parse_gns(struct minmea_sentence_gns *frame, const char *sentence)
 {
     // $GNGNS,103600.01,5114.51176,N,00012.29380,W,ANNN,07,1.18,111.5,45.6,,,V*00
     char type[6];
-    static char value[7]; // TODO: 7 may be a limit...increase? Also, altenative is pass a buffer to hold this, instead of declaring as static
+    // NOTE: NMEA revealed says the posMode field can be 1-4 chars, however, some receivers have more (ublox MAXM10S returns 6)
+    static char value[10]; // Altenative is pass a buffer to hold this, instead of declaring as static
     int latitude_direction;
     int longitude_direction;
     if (!minmea_scan(sentence, "tTfdfdsifffiic",

--- a/minmea.h
+++ b/minmea.h
@@ -74,7 +74,7 @@ struct minmea_sentence_gns {
     struct minmea_time time;
     struct minmea_float latitude;
     struct minmea_float longitude;
-    char* posMode; // TODO: check this works
+    char* posMode;
     int numSV;
     struct minmea_float hdop;
     struct minmea_float altitude;

--- a/minmea.h
+++ b/minmea.h
@@ -231,6 +231,7 @@ bool minmea_scan(const char *sentence, const char *format, ...);
  * Parse a specific type of sentence. Return true on success.
  */
 bool minmea_parse_gbs(struct minmea_sentence_gbs *frame, const char *sentence);
+bool minmea_parse_gns(struct minmea_sentence_gns *frame, const char *sentence);
 bool minmea_parse_rmc(struct minmea_sentence_rmc *frame, const char *sentence);
 bool minmea_parse_gga(struct minmea_sentence_gga *frame, const char *sentence);
 bool minmea_parse_gsa(struct minmea_sentence_gsa *frame, const char *sentence);

--- a/minmea.h
+++ b/minmea.h
@@ -74,12 +74,14 @@ struct minmea_sentence_gns {
     struct minmea_time time;
     struct minmea_float latitude;
     struct minmea_float longitude;
-    char posMode; // keep it char??
+    char* posMode; // TODO: check this works
     int numSV;
     struct minmea_float hdop;
     struct minmea_float altitude;
     struct minmea_float separation;
-    bool valid;
+    int diffAge;
+    int diffStation;
+    char navStatus;
 };
 
 struct minmea_sentence_rmc {

--- a/minmea.h
+++ b/minmea.h
@@ -32,6 +32,7 @@ enum minmea_sentence_id {
     MINMEA_SENTENCE_GBS,
     MINMEA_SENTENCE_GGA,
     MINMEA_SENTENCE_GLL,
+    MINMEA_SENTENCE_GNS,
     MINMEA_SENTENCE_GSA,
     MINMEA_SENTENCE_GST,
     MINMEA_SENTENCE_GSV,
@@ -67,6 +68,18 @@ struct minmea_sentence_gbs {
     struct minmea_float prob;
     struct minmea_float bias;
     struct minmea_float stddev;
+};
+
+struct minmea_sentence_gns {
+    struct minmea_time time;
+    struct minmea_float latitude;
+    struct minmea_float longitude;
+    char posMode; // keep it char??
+    int numSV;
+    struct minmea_float hdop;
+    struct minmea_float altitude;
+    struct minmea_float separation;
+    bool valid;
 };
 
 struct minmea_sentence_rmc {

--- a/tests.c
+++ b/tests.c
@@ -515,6 +515,53 @@ START_TEST(test_minmea_parse_gbs2)
 }
 END_TEST
 
+START_TEST(test_minmea_parse_gns1)
+{
+    const char *sentence = "$GNGNS,183734.00,3841.26267,N,09015.35134,W,ANAANN,15,2.15,220.0,-32.0,,,V*2F";
+    struct minmea_sentence_gns frame = {};
+    // TODO: confirm my assumptions here
+    static const struct minmea_sentence_gns expected = {
+        .time = { 18, 37, 34 },
+        .latitude = { 384126267, 100000 },
+        .longitude = { -901535134, 100000 },
+        .posMode = "ANAANN",
+        .numSV = 15,
+        .hdop = { 215, 100 },
+        .altitude = { 2200, 10 },
+        .separation = { -320, 10 },
+        .diffAge = 0,
+        .diffStation = 0, // if not included, what should they be??
+        .navStatus = 'V',
+    };
+    ck_assert(minmea_check(sentence, false) == true);
+    ck_assert(minmea_check(sentence, true) == true);
+    ck_assert(minmea_parse_gns(&frame, sentence) == true);
+    ck_assert(!memcmp(&frame, &expected, sizeof(frame)));
+}
+
+START_TEST(test_minmea_parse_gns2)
+{
+    const char *sentence = "$GNGNS,183737.00,3841.26462,N,09015.35010,W,AAAA,16,1.15,220.8,-32.0,100,5,V";
+    struct minmea_sentence_gns frame = {};
+    static const struct minmea_sentence_gns expected = {
+        .time = { 18, 37, 37 },
+        .latitude = { 384126462, 100000 },
+        .longitude = { -901535010, 100000 },
+        .posMode = "AAAA",
+        .numSV = 16,
+        .hdop = { 115, 100 },
+        .altitude = { 2208, 10 },
+        .separation = { -320, 10 },
+        .diffAge = 100,
+        .diffStation = 5,
+        .navStatus = 'V',
+    };
+    ck_assert(minmea_check(sentence, false) == true);
+    ck_assert(minmea_check(sentence, true) == false);
+    ck_assert(minmea_parse_gns(&frame, sentence) == true);
+    ck_assert(!memcmp(&frame, &expected, sizeof(frame)));
+}
+
 START_TEST(test_minmea_parse_rmc1)
 {
     const char *sentence = "$GPRMC,081836.75,A,3751.65,S,14507.36,E,000.0,360.0,130998,011.3,E";
@@ -1161,6 +1208,8 @@ static Suite *minmea_suite(void)
     TCase *tc_parse = tcase_create("minmea_parse");
     tcase_add_test(tc_parse, test_minmea_parse_gbs1);
     tcase_add_test(tc_parse, test_minmea_parse_gbs2);
+    tcase_add_test(tc_parse, test_minmea_parse_gns1);
+    tcase_add_test(tc_parse, test_minmea_parse_gns2);
     tcase_add_test(tc_parse, test_minmea_parse_rmc1);
     tcase_add_test(tc_parse, test_minmea_parse_rmc2);
     tcase_add_test(tc_parse, test_minmea_parse_gga1);

--- a/tests.c
+++ b/tests.c
@@ -519,9 +519,8 @@ START_TEST(test_minmea_parse_gns1)
 {
     const char *sentence = "$GNGNS,183734.00,3841.26267,N,09015.35134,W,ANAANN,15,2.15,220.0,-32.0,,,V*2F";
     struct minmea_sentence_gns frame = {};
-    // TODO: confirm my assumptions here
     static const struct minmea_sentence_gns expected = {
-        .time = { 18, 37, 34 },
+        .time = { 18, 37, 34, 0 },
         .latitude = { 384126267, 100000 },
         .longitude = { -901535134, 100000 },
         .posMode = "ANAANN",
@@ -530,14 +529,24 @@ START_TEST(test_minmea_parse_gns1)
         .altitude = { 2200, 10 },
         .separation = { -320, 10 },
         .diffAge = 0,
-        .diffStation = 0, // if not included, what should they be??
+        .diffStation = 0,
         .navStatus = 'V',
     };
     ck_assert(minmea_check(sentence, false) == true);
     ck_assert(minmea_check(sentence, true) == true);
     ck_assert(minmea_parse_gns(&frame, sentence) == true);
-    ck_assert(!memcmp(&frame, &expected, sizeof(frame)));
+
+    ck_assert(!memcmp(&frame, &expected, 32)); // memcmp everything up to string
+    ck_assert(!strncmp(frame.posMode, expected.posMode, strnlen(frame.posMode, MINMEA_MAX_SENTENCE_LENGTH)));
+    ck_assert(frame.numSV == expected.numSV);
+    ck_assert(frame.hdop.scale == expected.hdop.scale && frame.hdop.value == frame.hdop.value);
+    ck_assert(frame.altitude.value == expected.altitude.value && frame.altitude.scale == expected.altitude.scale);
+    ck_assert(frame.separation.value == expected.separation.value && frame.separation.scale == expected.separation.scale);
+    ck_assert(frame.diffAge == expected.diffAge);
+    ck_assert(frame.diffStation == expected.diffStation);
+    ck_assert(frame.navStatus == expected.navStatus);
 }
+END_TEST
 
 START_TEST(test_minmea_parse_gns2)
 {
@@ -559,8 +568,18 @@ START_TEST(test_minmea_parse_gns2)
     ck_assert(minmea_check(sentence, false) == true);
     ck_assert(minmea_check(sentence, true) == false);
     ck_assert(minmea_parse_gns(&frame, sentence) == true);
-    ck_assert(!memcmp(&frame, &expected, sizeof(frame)));
+
+    ck_assert(!memcmp(&frame, &expected, 32)); // memcmp everything up to string
+    ck_assert(!strncmp(frame.posMode, expected.posMode, strnlen(frame.posMode, MINMEA_MAX_SENTENCE_LENGTH)));
+    ck_assert(frame.numSV == expected.numSV);
+    ck_assert(frame.hdop.scale == expected.hdop.scale && frame.hdop.value == frame.hdop.value);
+    ck_assert(frame.altitude.value == expected.altitude.value && frame.altitude.scale == expected.altitude.scale);
+    ck_assert(frame.separation.value == expected.separation.value && frame.separation.scale == expected.separation.scale);
+    ck_assert(frame.diffAge == expected.diffAge);
+    ck_assert(frame.diffStation == expected.diffStation);
+    ck_assert(frame.navStatus == expected.navStatus);
 }
+END_TEST
 
 START_TEST(test_minmea_parse_rmc1)
 {


### PR DESCRIPTION
The GNS sentence is fix data, but for the multi-GNSS systems. It's similar to GGA, but GGA is GPS specific. Adding this would help support more general multi-GNSS solutions.