### PR TITLE
[build] Execute installation steps for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,3 +37,16 @@ if (SCAN_FOUND)
 else()
     MESSAGE(STATUS "scan-build not found, not scanning code")
 endif()
+
+include(GNUInstallDirs)
+
+install(TARGETS minmea
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install(FILES minmea.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if(MSVC)
+    install(FILES compat/minmea_compat_windows.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        RENAME minmea_compat.h)
+endif()


### PR DESCRIPTION
Hello!

This PR brings the support of installing the library and header, directly by using CMake:

```
cmake --fresh -S . -B build -DCMAKE_INSTALL_PREFIX=/tmp/install 
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Check for working C compiler: /usr/local/bin/cc
-- Check for working C compiler: /usr/local/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/local/bin/c++
-- Check for working CXX compiler: /usr/local/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.1") 
-- Checking for module 'check'
--   Found check, version 0.15.2
-- scan-build not found, not scanning code
-- Configuring done
-- Generating done
-- Build files have been written to: /home/conan/project/build

$ cmake --build build --target install 
Scanning dependencies of target minmea
[ 16%] Building C object CMakeFiles/minmea.dir/minmea.c.o
[ 33%] Linking C static library libminmea.a
[ 33%] Built target minmea
Scanning dependencies of target example
[ 50%] Building C object CMakeFiles/example.dir/example.c.o
[ 66%] Linking C executable example
[ 66%] Built target example
Scanning dependencies of target tests
[ 83%] Building C object CMakeFiles/tests.dir/tests.c.o
[100%] Linking C executable tests
[100%] Built target tests
Install the project...
-- Install configuration: ""
-- Installing: /tmp/install/lib/libminmea.a
-- Installing: /tmp/install/include/minmea.h
```

So users do not need know what should be copied manually, but can use CMake as well to install the artifacts.

Regards! 