### PR TITLE
Make testing configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,18 +26,12 @@ if (MINMEA_ENABLE_TESTING)
     target_compile_options(tests PUBLIC ${CHECK_CFLAGS_OTHER})
 
     add_test(NAME tests COMMAND $<TARGET_FILE:tests>)
+    add_test(
+        NAME clang_static_analysis
+        COMMAND scan-build make
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
     list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
-
-    find_program(SCAN_FOUND scan-build)
-    if (SCAN_FOUND)
-        add_test(
-            NAME clang_static_analysis
-            COMMAND scan-build make
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        )
-    else()
-        MESSAGE(STATUS "scan-build not found, not scanning code")
-    endif()
 endif()
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,16 @@
 cmake_minimum_required(VERSION 3.3)
 
-enable_testing()
+option(MINMEA_ENABLE_TESTING "Enable building and running unit tests" ON)
 
 project(minmea)
 
-find_package(Threads REQUIRED) # Workaround for https://github.com/libcheck/check/issues/48#issuecomment-322965461
-find_package(PkgConfig)
-pkg_check_modules(CHECK REQUIRED check)
-link_directories(${CHECK_LIBRARY_DIRS})
+if (MINMEA_ENABLE_TESTING)
+    enable_testing()
+    find_package(Threads REQUIRED) # Workaround for https://github.com/libcheck/check/issues/48#issuecomment-322965461
+    find_package(PkgConfig)
+    pkg_check_modules(CHECK REQUIRED check)
+    link_directories(${CHECK_LIBRARY_DIRS})
+endif()
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -Werror -std=c99")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_POSIX_C_SOURCE=199309L -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_DARWIN_C_SOURCE")
@@ -18,24 +21,25 @@ add_library(minmea ${minmea_SRCS})
 add_executable(example example.c)
 target_link_libraries(example minmea)
 
-add_executable(tests tests.c)
-target_link_libraries(tests minmea ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-target_include_directories(tests PUBLIC ${CHECK_INCLUDE_DIRS})
-target_compile_options(tests PUBLIC ${CHECK_CFLAGS_OTHER})
+if (MINMEA_ENABLE_TESTING)
+    add_executable(tests tests.c)
+    target_link_libraries(tests minmea ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    target_include_directories(tests PUBLIC ${CHECK_INCLUDE_DIRS})
+    target_compile_options(tests PUBLIC ${CHECK_CFLAGS_OTHER})
 
-add_test(NAME tests COMMAND $<TARGET_FILE:tests>)
-list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
+    add_test(NAME tests COMMAND $<TARGET_FILE:tests>)
+    list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
 
-find_program(SCAN_FOUND scan-build)
-
-if (SCAN_FOUND)
-    add_test(
-        NAME clang_static_analysis
-        COMMAND scan-build make
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    )
-else()
-    MESSAGE(STATUS "scan-build not found, not scanning code")
+    find_program(SCAN_FOUND scan-build)
+    if (SCAN_FOUND)
+        add_test(
+            NAME clang_static_analysis
+            COMMAND scan-build make
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        )
+    else()
+        MESSAGE(STATUS "scan-build not found, not scanning code")
+    endif()
 endif()
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,8 @@
 cmake_minimum_required(VERSION 3.3)
 
-option(MINMEA_ENABLE_TESTING "Enable building and running unit tests" ON)
-
 project(minmea)
 
-if (MINMEA_ENABLE_TESTING)
-    enable_testing()
-    find_package(Threads REQUIRED) # Workaround for https://github.com/libcheck/check/issues/48#issuecomment-322965461
-    find_package(PkgConfig)
-    pkg_check_modules(CHECK REQUIRED check)
-    link_directories(${CHECK_LIBRARY_DIRS})
-endif()
+option(MINMEA_ENABLE_TESTING "Enable building and running unit tests" ON)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -Werror -std=c99")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_POSIX_C_SOURCE=199309L -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_DARWIN_C_SOURCE")
@@ -22,6 +14,12 @@ add_executable(example example.c)
 target_link_libraries(example minmea)
 
 if (MINMEA_ENABLE_TESTING)
+    enable_testing()
+    find_package(Threads REQUIRED) # Workaround for https://github.com/libcheck/check/issues/48#issuecomment-322965461
+    find_package(PkgConfig)
+    pkg_check_modules(CHECK REQUIRED check)
+    link_directories(${CHECK_LIBRARY_DIRS})
+
     add_executable(tests tests.c)
     target_link_libraries(tests minmea ${CHECK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
     target_include_directories(tests PUBLIC ${CHECK_INCLUDE_DIRS})

--- a/README.md
+++ b/README.md
@@ -146,6 +146,17 @@ make
 make test
 ```
 
+## Building without unit tests
+
+It's possible to build the library without the unit tests and their dependencies.
+
+```console
+mkdir build
+cd build
+cmake -DMINMEA_ENABLE_TESTING=OFF ..
+make
+```
+
 ## Limitations
 
 * Only a handful of frames is supported right now.


### PR DESCRIPTION
For builds that don't require testing, avoid the testing dependencies.