### PR TITLE
Initialize sentence type before scanning.

### DIFF
--- a/minmea.c
+++ b/minmea.c
@@ -352,7 +352,7 @@ enum minmea_sentence_id minmea_sentence_id(const char *sentence, bool strict)
     if (!minmea_check(sentence, strict))
         return MINMEA_INVALID;
 
-    char type[6];
+    char type[6] = { 0, 0, 0, 0, 0, 0 };
     if (!minmea_scan(sentence, "t", type))
         return MINMEA_INVALID;
 


### PR DESCRIPTION
This fixes Valgrind's warning about conditional jump depending on uninitialized memory. It also fixes an intermittent issue where the final \0 byte was unitinialized memory, causing subsequent strcmp to fail.

This could be seen in Valgrind:

```
==3283597== Conditional jump or move depends on uninitialised value(s)
==3283597==    at 0x486C1AF: strcmp (vg_replace_strmem.c:941)
==3283597==    by 0x400F046: minmea_sentence_id (minmea.c:367)
==3283597==    by 0x400B431: test_minmea_usage1_fn (tests.c:991)
==3283597==    by 0x48AB1C8: UnknownInlinedFun (check_run.c:497)
==3283597==    by 0x48AB1C8: UnknownInlinedFun (check_run.c:256)
==3283597==    by 0x48AB1C8: UnknownInlinedFun (check_run.c:402)
==3283597==    by 0x48AB1C8: UnknownInlinedFun (check_run.c:222)
==3283597==    by 0x48AB1C8: srunner_run_tagged (check_run.c:814)
==3283597==    by 0x400DEAC: main (tests.c:1220)
```

For me the original code happened to work for GGA:

```
(gdb) print type
$6 = "GNGGA"
```

but not for RMC:
``` 
(gdb) print type
$5 = "GNRMC|"
```

The exact sentence type doesn't matter, I just happened to see it when I first parsed GGA and then RMC.