### PR TITLE
When the altitude is high, the length of the GGA sentence will exceed…

### DIFF
--- a/minmea.h
+++ b/minmea.h
@@ -23,7 +23,7 @@ extern "C" {
 #endif
 
 #ifndef MINMEA_MAX_SENTENCE_LENGTH
-#define MINMEA_MAX_SENTENCE_LENGTH 80
+#define MINMEA_MAX_SENTENCE_LENGTH 256
 #endif
 
 enum minmea_sentence_id {


### PR DESCRIPTION
When the altitude is high, the length of the GGA sentence will exceed the original length of MINMEA_MAX_SENTENCE_LENGTH by 80. example.c will fail to parse the GGA sentence. Change the default length of MINMEA_MAX_SENTENCE_LENGTH to 256.